### PR TITLE
Make foreign key columns unsigned

### DIFF
--- a/src/database/migrations/2016_01_01_145745_create_role_user_table.php
+++ b/src/database/migrations/2016_01_01_145745_create_role_user_table.php
@@ -14,8 +14,8 @@ class CreateRoleUserTable extends Migration
     {
         Schema::create('role_user', function (Blueprint $table) {
             $table->increments('id');
-            $table->integer('role_id')->index()->foreign()->references('id')->on('roles')->onDelete('cascade');
-            $table->integer('user_id')->index()->foreign()->references('id')->on('users')->onDelete('cascade');
+            $table->integer('role_id')->unsigned()->index()->foreign()->references('id')->on('roles')->onDelete('cascade');
+            $table->integer('user_id')->unsigned()->index()->foreign()->references('id')->on('users')->onDelete('cascade');
             $table->timestamps();
         });
     }

--- a/src/database/migrations/2016_01_01_154441_create_permission_role_table.php
+++ b/src/database/migrations/2016_01_01_154441_create_permission_role_table.php
@@ -14,8 +14,8 @@ class CreatePermissionRoleTable extends Migration
     {
         Schema::create('permission_role', function (Blueprint $table) {
             $table->increments('id');
-            $table->integer('permission_id')->index()->foreign()->references('id')->on('permissions')->onDelete('cascade');
-            $table->integer('role_id')->index()->foreign()->references('id')->on('roles')->onDelete('cascade');
+            $table->integer('permission_id')->unsigned()->index()->foreign()->references('id')->on('permissions')->onDelete('cascade');
+            $table->integer('role_id')->unsigned()->index()->foreign()->references('id')->on('roles')->onDelete('cascade');
             $table->timestamps();
         });
     }


### PR DESCRIPTION
Make columns 'role_id' and 'user_id' in 'role_user' table, and
columns 'role_id' and 'permission_id' in 'permission_role' table
unsigned, as the columns they point to are also unsigned.
